### PR TITLE
(chore): unignore `client.py`

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -2,7 +2,6 @@
 
 .github/workflows/ci.yml
 
-src/vectara/client.py
 src/vectara/auth/client.py
 
 src/vectara/config/


### PR DESCRIPTION
This PR un fernignores the top level `client.py`