### PR TITLE
Fix: Suppress mypy errors in Fern auto-generated files

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,12 @@
 [mypy]
 plugins = pydantic.mypy
 
+[mypy-httpx_sse.*]
+ignore_missing_imports = True
+
+[mypy-vectara.agent_events.types.*]
+ignore_errors = True
+
 [mypy-publication.*]
 ignore_missing_imports = True
 ignore_errors = True


### PR DESCRIPTION
## Summary
- Suppresses mypy errors caused by Fern generator bugs in auto-generated code
- `httpx_sse`: missing type stubs
- `agent_events.types`: `stream_response` type conflict (`Optional[bool]` vs `Literal[True/False]`)
- Both scoped only to auto-generated files, no impact on manual code

## Test plan
- [ ] CI compile job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)