### PR TITLE
Remove base_client.py from .fernignore

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -4,7 +4,7 @@
 .github/ISSUE_TEMPLATE/
 
 src/vectara/client.py
-src/vectara/base_client.py # custom api_key auth path added
+# src/vectara/base_client.py — Fern now generates api_key auth natively (auth: any config)
 src/vectara/auth/client.py
 
 src/vectara/config/


### PR DESCRIPTION
## Summary

Removes `base_client.py` from `.fernignore` so Fern can fully regenerate it.

## Why

Fern now supports `api_key` as a native auth scheme via the `auth: any` config added in vectara/docs#565. This means `base_client.py` no longer needs our custom `api_key`-only authentication path — Fern will generate it natively with:

```yaml
auth-schemes:
  OAuthScheme:
    scheme: oauth
    ...
  ApiKey:
    header: x-api-key
    type: string
    env: VECTARA_API_KEY
api:
  auth:
    any:
      - OAuthScheme
      - ApiKey
```

## Merge order

1. Merge docs PR vectara/docs#565 (auth config fix)
2. Merge this PR
3. Trigger Fern SDK generation — `base_client.py` will be regenerated with native api_key + OAuth support

## Test plan
- [ ] After Fern regeneration, verify `Vectara(api_key="...")` works
- [ ] Verify `Vectara(client_id="...", client_secret="...")` still works
- [ ] Run SDK test suite from api_test_suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)